### PR TITLE
NP-2388 monitoring manager org app stats

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -10,12 +10,39 @@
   version = "v1.0.1"
 
 [[projects]]
+  digest = "1:0deddd908b6b4b768cfc272c16ee61e7088a60f7fe2f06c547bd3d8e1f8b8e77"
+  name = "github.com/davecgh/go-spew"
+  packages = ["spew"]
+  pruneopts = ""
+  revision = "8991bc29aa16c548c550c7ff78260e27b9ab7c73"
+  version = "v1.1.1"
+
+[[projects]]
   digest = "1:eb53021a8aa3f599d29c7102e65026242bdedce998a54837dc67f14b6a97c5fd"
   name = "github.com/fsnotify/fsnotify"
   packages = ["."]
   pruneopts = ""
   revision = "c2828203cd70a50dcccfb2761f8b1f8ceef9a8e9"
   version = "v1.4.7"
+
+[[projects]]
+  digest = "1:d69d2ba23955582a64e367ff2b0808cdbd048458c178cea48f11ab8c40bd7aea"
+  name = "github.com/gogo/protobuf"
+  packages = [
+    "proto",
+    "sortkeys",
+  ]
+  pruneopts = ""
+  revision = "5628607bb4c51c3157aacc3a50f0ab707582b805"
+  version = "v1.3.1"
+
+[[projects]]
+  branch = "master"
+  digest = "1:107b233e45174dbab5b1324201d092ea9448e58243ab9f039e4c0f332e121e3a"
+  name = "github.com/golang/glog"
+  packages = ["."]
+  pruneopts = ""
+  revision = "23def4e6c14b4da8ac2ed8007337bc5eb5007998"
 
 [[projects]]
   digest = "1:b852d2b62be24e445fcdbad9ce3015b44c207815d631230dfce3f14e7803f5bf"
@@ -37,6 +64,45 @@
   version = "v1.3.2"
 
 [[projects]]
+  digest = "1:1e5b1e14524ed08301977b7b8e10c719ed853cbf3f24ecb66fae783a46f207a6"
+  name = "github.com/google/btree"
+  packages = ["."]
+  pruneopts = ""
+  revision = "4030bb1f1f0c35b30ca7009e9ebd06849dd45306"
+  version = "v1.0.0"
+
+[[projects]]
+  digest = "1:8d4a577a9643f713c25a32151c0f26af7228b4b97a219b5ddb7fd38d16f6e673"
+  name = "github.com/google/gofuzz"
+  packages = ["."]
+  pruneopts = ""
+  revision = "f140a6486e521aad38f5917de355cbf147cc0496"
+  version = "v1.0.0"
+
+[[projects]]
+  digest = "1:728f28282e0edc47e2d8f41c9ec1956ad645ad6b15e6376ab31e2c3b094fc38f"
+  name = "github.com/googleapis/gnostic"
+  packages = [
+    "OpenAPIv2",
+    "compiler",
+    "extensions",
+  ]
+  pruneopts = ""
+  revision = "ab0dd09aa10e2952b28e12ecd35681b20463ebab"
+  version = "v0.3.1"
+
+[[projects]]
+  branch = "master"
+  digest = "1:e1fd67b5695fb12f54f979606c5d650a5aa72ef242f8e71072bfd4f7b5a141a0"
+  name = "github.com/gregjones/httpcache"
+  packages = [
+    ".",
+    "diskcache",
+  ]
+  pruneopts = ""
+  revision = "901d90724c7919163f472a9812253fb26761123d"
+
+[[projects]]
   digest = "1:a82fe90cbcaf5dfc8267a0b49e0ab0a67c636532c83b21326f5000817ef20d5b"
   name = "github.com/grpc-ecosystem/grpc-gateway"
   packages = [
@@ -47,6 +113,17 @@
   pruneopts = ""
   revision = "f7120437bb4f6c71f7f5076ad65a45310de2c009"
   version = "v1.12.1"
+
+[[projects]]
+  digest = "1:7f6f07500a0b7d3766b00fa466040b97f2f5b5f3eef2ecabfe516e703b05119a"
+  name = "github.com/hashicorp/golang-lru"
+  packages = [
+    ".",
+    "simplelru",
+  ]
+  pruneopts = ""
+  revision = "7f827b33c0f158ec5dfbba01bb0b14a4541fd81d"
+  version = "v0.5.3"
 
 [[projects]]
   digest = "1:b3c5b95e56c06f5aa72cb2500e6ee5f44fcd122872d4fec2023a488e561218bc"
@@ -63,6 +140,14 @@
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:6906c992632a66c125bd44e68a7abc354d9eda683e451b5c2d9b1614d15d4f18"
+  name = "github.com/imdario/mergo"
+  packages = ["."]
+  pruneopts = ""
+  revision = "1afb36080aec31e0d1528973ebe6721b191b0369"
+  version = "v0.3.8"
+
+[[projects]]
   digest = "1:870d441fe217b8e689d7949fef6e43efbc787e50f200cb1e70dbca9204a1d6be"
   name = "github.com/inconshreveable/mousetrap"
   packages = ["."]
@@ -71,12 +156,55 @@
   version = "v1.0"
 
 [[projects]]
+  digest = "1:64bdeae058b988b2b198326b1ca6155497e904e697348d838add8a6e4c25842e"
+  name = "github.com/json-iterator/go"
+  packages = ["."]
+  pruneopts = ""
+  revision = "03217c3e97663914aec3faafde50d081f197a0a2"
+  version = "v1.1.8"
+
+[[projects]]
   digest = "1:63722a4b1e1717be7b98fc686e0b30d5e7f734b9e93d7dee86293b6deab7ea28"
   name = "github.com/matttproud/golang_protobuf_extensions"
   packages = ["pbutil"]
   pruneopts = ""
   revision = "c12348ce28de40eed0136aa2b644d0ee0650e56c"
   version = "v1.0.1"
+
+[[projects]]
+  digest = "1:0c0ff2a89c1bb0d01887e1dac043ad7efbf3ec77482ef058ac423d13497e16fd"
+  name = "github.com/modern-go/concurrent"
+  packages = ["."]
+  pruneopts = ""
+  revision = "bacd9c7ef1dd9b15be4a9909b8ac7a4e313eec94"
+  version = "1.0.3"
+
+[[projects]]
+  digest = "1:e32bdbdb7c377a07a9a46378290059822efdce5c8d96fe71940d87cb4f918855"
+  name = "github.com/modern-go/reflect2"
+  packages = ["."]
+  pruneopts = ""
+  revision = "4b7aa43c6742a2c18fdef89dd197aaae7dac7ccd"
+  version = "1.0.1"
+
+[[projects]]
+  digest = "1:4bc382a76fc85eaea5a9a8c7c79d6e8285a1dc1b346c91e8287bdf70558b1d90"
+  name = "github.com/nalej/deployment-manager"
+  packages = [
+    "internal/entities",
+    "internal/structures/monitor",
+    "pkg/common",
+    "pkg/config",
+    "pkg/executor",
+    "pkg/kubernetes",
+    "pkg/kubernetes/events",
+    "pkg/metrics",
+    "pkg/utils",
+    "version",
+  ]
+  pruneopts = ""
+  revision = "c4bcc5b63851087037708490931411b28bfd33a2"
+  version = "v0.4.0"
 
 [[projects]]
   digest = "1:b651ba0ea8155a78a3a2b23e4cc86f85c44ce62856a565632444eb418d0d960e"
@@ -103,12 +231,12 @@
   version = "v0.0.26"
 
 [[projects]]
-  digest = "1:db80629ec1cb6f46cf6c92f350131811fc773fc67b5f9d5b57a84c1a01183613"
+  digest = "1:b6844eec3faae47051ba88f4c003264e94833a3cc74de0f7e6bd936ccf7ca19b"
   name = "github.com/nalej/grpc-application-go"
   packages = ["."]
   pruneopts = ""
-  revision = "23d094052316a074143e6fc61c5436320c8e2fb0"
-  version = "v0.0.91"
+  revision = "27d9d79c7f2d3967057c0934355660d6615d1c45"
+  version = "v0.0.86"
 
 [[projects]]
   digest = "1:14935510a150a010a7cb713d816fe04abc36fca1130778c36d1f0be7b15cc9e0"
@@ -143,12 +271,12 @@
   version = "v0.0.38"
 
 [[projects]]
-  digest = "1:442429f610e3934106628ab549ddce78c45195ded6ba88ad76339b2a7756dc27"
+  digest = "1:b20974f33d5927364de58b99328ee8bdbb23fa0911a92e3a868afec5d92d5466"
   name = "github.com/nalej/grpc-conductor-go"
   packages = ["."]
   pruneopts = ""
-  revision = "9cbe44351c8dbd004186abc61dff0430d497022a"
-  version = "v0.0.96"
+  revision = "7895e36f8e79a9219e48f5a1c72296d1f3928231"
+  version = "v0.0.92"
 
 [[projects]]
   digest = "1:98b6027953482c9efb9ff40892c51d876d819a3a58543c7b5eb7c099c90d2d13"
@@ -159,12 +287,12 @@
   version = "v0.0.4"
 
 [[projects]]
-  digest = "1:b23dd1094f2e65cf138000ced92de82d70b0811b8a3fc03e7e4df79bba44e751"
+  digest = "1:48da8aeeabb8f5ae90903b1f1e38174bc181ab47f57fd1e8e92acefdffb16d0c"
   name = "github.com/nalej/grpc-deployment-manager-go"
   packages = ["."]
   pruneopts = ""
-  revision = "96a4d8dd785889c54cab647b604bb1d45fe57f00"
-  version = "v0.0.64"
+  revision = "c225918c521b22fe9c6409fb07ae867c91de890e"
+  version = "v0.0.63"
 
 [[projects]]
   digest = "1:26321a3340b5dde398bd8ec308e3b54d129e55a9cd70cdba293a63f729244c80"
@@ -207,6 +335,14 @@
   version = "v0.0.49"
 
 [[projects]]
+  digest = "1:b73cffaf6365350acb43710662f5a38d3d0532f9b687f8283d0fcfc56d800eed"
+  name = "github.com/nalej/grpc-installer-go"
+  packages = ["."]
+  pruneopts = ""
+  revision = "8224f729b66293d88afaa6b3c4ec91b60f6f6b7c"
+  version = "v0.0.35"
+
+[[projects]]
   digest = "1:52d4ed526ec58b9544a3cec008022015f95d025032a82320f8e53a799cc1d721"
   name = "github.com/nalej/grpc-inventory-go"
   packages = ["."]
@@ -223,20 +359,20 @@
   version = "v0.0.57"
 
 [[projects]]
-  digest = "1:07cb0a9bbb3b276d6a0ff63a1e3105f81ea66e9580f52b3ad282d8bbf4d9019b"
+  digest = "1:5c3d2751e210c6df160ecdc425d42220dfff4b1cf7825ebc4a1d69820efdf8d2"
   name = "github.com/nalej/grpc-monitoring-go"
   packages = ["."]
   pruneopts = ""
-  revision = "3a274cb674edbf3f2e3504934cbc4dd1a2399b98"
-  version = "v0.0.9"
+  revision = "4bea22eebfac63bd200e0a00be1d1bf58c34ff0e"
+  version = "v0.0.12"
 
 [[projects]]
-  digest = "1:a38c55f4ee4da38689b71b5fbd0d0f2902657546dd39d49e5a5beb8c6b4f1e5c"
+  digest = "1:c824ac5b757663d20803e64ba66757c4678c5a338401305ad021069d3cefbc45"
   name = "github.com/nalej/grpc-network-go"
   packages = ["."]
   pruneopts = ""
-  revision = "d16d18d906572a8eab6419951f140753f28fcd54"
-  version = "v0.0.46"
+  revision = "2041cb4a8fcd8ba7972c739aaa34b3e0713b9cda"
+  version = "v0.0.45"
 
 [[projects]]
   digest = "1:ba1b6bc93bc388dddeb0db8975ca32312921508dfff13803fb58c623c2350908"
@@ -255,12 +391,12 @@
   version = "v0.0.3"
 
 [[projects]]
-  digest = "1:1870a2fdb0c64a4559db09751d8f9961419c6b0b270293ea523e294b362098c0"
+  digest = "1:18d316170b65da520a335ae2e11818ed9a481cb57d8fb6c72ee2dc437bb148c4"
   name = "github.com/nalej/grpc-unified-logging-go"
   packages = ["."]
   pruneopts = ""
-  revision = "584d5f2609960879356f983328ae6aefe0358932"
-  version = "v0.0.10"
+  revision = "206ef6835662f9ab80271758948b247756d9284b"
+  version = "v0.0.11"
 
 [[projects]]
   digest = "1:3c48d4db5e7f6c3cda75e4fc1f9b061eb121ec26587bec82059eba37bac619be"
@@ -330,6 +466,22 @@
   version = "v1.7.1"
 
 [[projects]]
+  branch = "master"
+  digest = "1:5f0faa008e8ff4221b55a1a5057c8b02cb2fd68da6a65c9e31c82b72cbc836d0"
+  name = "github.com/petar/GoLLRB"
+  packages = ["llrb"]
+  pruneopts = ""
+  revision = "33fb24c13b99c46c93183c291836c573ac382536"
+
+[[projects]]
+  digest = "1:4709c61d984ef9ba99b037b047546d8a576ae984fb49486e48d99658aa750cd5"
+  name = "github.com/peterbourgon/diskv"
+  packages = ["."]
+  pruneopts = ""
+  revision = "0be1b92a6df0e4f5cb0a5d15fb7f643d0ad93ce6"
+  version = "v3.0.0"
+
+[[projects]]
   digest = "1:6f218995d6a74636cfcab45ce03005371e682b4b9bee0e5eb0ccfd83ef85364f"
   name = "github.com/prometheus/client_golang"
   packages = [
@@ -345,11 +497,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:0a565f69553dd41b3de790fde3532e9237142f2637899e20cd3e7396f0c4f2f7"
+  digest = "1:ff7a5f44653e65cf1a0577bbe3f2cdaf514930348f6df581bbd687bbe35ead5b"
   name = "github.com/prometheus/client_model"
   packages = ["go"]
   pruneopts = ""
-  revision = "14fe0d1b01d4d5fc031dd4bec1823bd3ebbe8016"
+  revision = "d1d2010b5beead3fa1c5f271a5cf626e40b3ad6e"
 
 [[projects]]
   digest = "1:8904acfa3ef080005c1fc0670ed0471739d1e211be5638cfa6af536b701942ae"
@@ -406,10 +558,19 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:97fc4d7b02ee1f310bb10f8ce213ae98190119ec8ff4b8aeb928766053405be8"
+  name = "golang.org/x/crypto"
+  packages = ["ssh/terminal"]
+  pruneopts = ""
+  revision = "86a70503ff7e82ffc18c7b0de83db35da4791e6a"
+
+[[projects]]
+  branch = "master"
   digest = "1:f58e146d19d1af39792c0b599b24b13de51f75b073ba52c1aa658fe535be9120"
   name = "golang.org/x/net"
   packages = [
     "context",
+    "context/ctxhttp",
     "html",
     "html/atom",
     "html/charset",
@@ -425,9 +586,23 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:44d75e002fa89506cca17f921eb07aee69526d7519bb7f1f2b0e017380c5e011"
+  name = "golang.org/x/oauth2"
+  packages = [
+    ".",
+    "internal",
+  ]
+  pruneopts = ""
+  revision = "858c2ad4c8b6c5d10852cb89079f6ca1c7309787"
+
+[[projects]]
+  branch = "master"
   digest = "1:6530ff3e6639af9bab7d2cf1e141c348e63af92058fa64d0660a6e8817d41640"
   name = "golang.org/x/sys"
-  packages = ["unix"]
+  packages = [
+    "unix",
+    "windows",
+  ]
   pruneopts = ""
   revision = "6d18c012aee9febd81bbf9806760c8c4480e870d"
 
@@ -467,6 +642,30 @@
   pruneopts = ""
   revision = "342b2e1fbaa52c93f31447ad2c6abc048c63e475"
   version = "v0.3.2"
+
+[[projects]]
+  branch = "master"
+  digest = "1:c43c206d0f8927031df6fc877cf58502af5ff875b76b4ceb6b617b676f7731f7"
+  name = "golang.org/x/time"
+  packages = ["rate"]
+  pruneopts = ""
+  revision = "555d28b269f0569763d25dbe1a237ae74c6bcc82"
+
+[[projects]]
+  digest = "1:c4404231035fad619a12f82ae3f0f8f9edc1cc7f34e7edad7a28ccac5336cc96"
+  name = "google.golang.org/appengine"
+  packages = [
+    "internal",
+    "internal/base",
+    "internal/datastore",
+    "internal/log",
+    "internal/remote_api",
+    "internal/urlfetch",
+    "urlfetch",
+  ]
+  pruneopts = ""
+  revision = "971852bfffca25b069c31162ae8f247a3dba083b"
+  version = "v1.6.5"
 
 [[projects]]
   branch = "master"
@@ -539,6 +738,14 @@
   version = "v1.4.7"
 
 [[projects]]
+  digest = "1:75fb3fcfc73a8c723efde7777b40e8e8ff9babf30d8c56160d01beffea8a95a6"
+  name = "gopkg.in/inf.v0"
+  packages = ["."]
+  pruneopts = ""
+  revision = "d2d2541c53f18d2a059457998ce2876cc8e67cbf"
+  version = "v0.9.1"
+
+[[projects]]
   branch = "v1"
   digest = "1:a96d16bd088460f2e0685d46c39bcf1208ba46e0a977be2df49864ec7da447dd"
   name = "gopkg.in/tomb.v1"
@@ -554,12 +761,186 @@
   revision = "1f64d6156d11335c3f22d9330b0ad14fc1e789ce"
   version = "v2.2.7"
 
+[[projects]]
+  digest = "1:8a3902b1f1aab51953de9741e4a62daaab441788d85ba7f50709ceca8e26b6ff"
+  name = "k8s.io/api"
+  packages = [
+    "admissionregistration/v1alpha1",
+    "admissionregistration/v1beta1",
+    "apps/v1",
+    "apps/v1beta1",
+    "apps/v1beta2",
+    "authentication/v1",
+    "authentication/v1beta1",
+    "authorization/v1",
+    "authorization/v1beta1",
+    "autoscaling/v1",
+    "autoscaling/v2beta1",
+    "autoscaling/v2beta2",
+    "batch/v1",
+    "batch/v1beta1",
+    "batch/v2alpha1",
+    "certificates/v1beta1",
+    "coordination/v1beta1",
+    "core/v1",
+    "events/v1beta1",
+    "extensions/v1beta1",
+    "networking/v1",
+    "policy/v1beta1",
+    "rbac/v1",
+    "rbac/v1alpha1",
+    "rbac/v1beta1",
+    "scheduling/v1alpha1",
+    "scheduling/v1beta1",
+    "settings/v1alpha1",
+    "storage/v1",
+    "storage/v1alpha1",
+    "storage/v1beta1",
+  ]
+  pruneopts = ""
+  revision = "5cb15d34447165a97c76ed5a60e4e99c8a01ecfe"
+  version = "kubernetes-1.13.5"
+
+[[projects]]
+  digest = "1:c05610391a133b223e1736a3b8cbd725da30f64c0c6a93d6422714ccfd8f4a73"
+  name = "k8s.io/apimachinery"
+  packages = [
+    "pkg/api/errors",
+    "pkg/api/meta",
+    "pkg/api/resource",
+    "pkg/apis/meta/internalversion",
+    "pkg/apis/meta/v1",
+    "pkg/apis/meta/v1/unstructured",
+    "pkg/apis/meta/v1beta1",
+    "pkg/conversion",
+    "pkg/conversion/queryparams",
+    "pkg/fields",
+    "pkg/labels",
+    "pkg/runtime",
+    "pkg/runtime/schema",
+    "pkg/runtime/serializer",
+    "pkg/runtime/serializer/json",
+    "pkg/runtime/serializer/protobuf",
+    "pkg/runtime/serializer/recognizer",
+    "pkg/runtime/serializer/streaming",
+    "pkg/runtime/serializer/versioning",
+    "pkg/selection",
+    "pkg/types",
+    "pkg/util/cache",
+    "pkg/util/clock",
+    "pkg/util/diff",
+    "pkg/util/errors",
+    "pkg/util/framer",
+    "pkg/util/intstr",
+    "pkg/util/json",
+    "pkg/util/naming",
+    "pkg/util/net",
+    "pkg/util/runtime",
+    "pkg/util/sets",
+    "pkg/util/validation",
+    "pkg/util/validation/field",
+    "pkg/util/wait",
+    "pkg/util/yaml",
+    "pkg/version",
+    "pkg/watch",
+    "third_party/forked/golang/reflect",
+  ]
+  pruneopts = ""
+  revision = "86fb29eff6288413d76bd8506874fddd9fccdff0"
+  version = "kubernetes-1.13.5"
+
+[[projects]]
+  digest = "1:5d4153d12c3aed2c90a94262520d2498d5afa4d692554af55e65a7c5af0bc399"
+  name = "k8s.io/client-go"
+  packages = [
+    "discovery",
+    "kubernetes",
+    "kubernetes/scheme",
+    "kubernetes/typed/admissionregistration/v1alpha1",
+    "kubernetes/typed/admissionregistration/v1beta1",
+    "kubernetes/typed/apps/v1",
+    "kubernetes/typed/apps/v1beta1",
+    "kubernetes/typed/apps/v1beta2",
+    "kubernetes/typed/authentication/v1",
+    "kubernetes/typed/authentication/v1beta1",
+    "kubernetes/typed/authorization/v1",
+    "kubernetes/typed/authorization/v1beta1",
+    "kubernetes/typed/autoscaling/v1",
+    "kubernetes/typed/autoscaling/v2beta1",
+    "kubernetes/typed/autoscaling/v2beta2",
+    "kubernetes/typed/batch/v1",
+    "kubernetes/typed/batch/v1beta1",
+    "kubernetes/typed/batch/v2alpha1",
+    "kubernetes/typed/certificates/v1beta1",
+    "kubernetes/typed/coordination/v1beta1",
+    "kubernetes/typed/core/v1",
+    "kubernetes/typed/events/v1beta1",
+    "kubernetes/typed/extensions/v1beta1",
+    "kubernetes/typed/networking/v1",
+    "kubernetes/typed/policy/v1beta1",
+    "kubernetes/typed/rbac/v1",
+    "kubernetes/typed/rbac/v1alpha1",
+    "kubernetes/typed/rbac/v1beta1",
+    "kubernetes/typed/scheduling/v1alpha1",
+    "kubernetes/typed/scheduling/v1beta1",
+    "kubernetes/typed/settings/v1alpha1",
+    "kubernetes/typed/storage/v1",
+    "kubernetes/typed/storage/v1alpha1",
+    "kubernetes/typed/storage/v1beta1",
+    "pkg/apis/clientauthentication",
+    "pkg/apis/clientauthentication/v1alpha1",
+    "pkg/apis/clientauthentication/v1beta1",
+    "pkg/version",
+    "plugin/pkg/client/auth/exec",
+    "rest",
+    "rest/watch",
+    "restmapper",
+    "tools/auth",
+    "tools/cache",
+    "tools/clientcmd",
+    "tools/clientcmd/api",
+    "tools/clientcmd/api/latest",
+    "tools/clientcmd/api/v1",
+    "tools/metrics",
+    "tools/pager",
+    "tools/reference",
+    "transport",
+    "util/buffer",
+    "util/cert",
+    "util/connrotation",
+    "util/flowcontrol",
+    "util/homedir",
+    "util/integer",
+    "util/retry",
+    "util/workqueue",
+  ]
+  pruneopts = ""
+  revision = "1638f8970cefaa404ff3a62950f88b08292b2696"
+  version = "v9.0.0"
+
+[[projects]]
+  digest = "1:7ce71844fcaaabcbe09a392902edb5790ddca3a7070ae8d20830dc6dbe2751af"
+  name = "k8s.io/klog"
+  packages = ["."]
+  pruneopts = ""
+  revision = "2ca9ad30301bf30a8a6e0fa2110db6b8df699a91"
+  version = "v1.0.0"
+
+[[projects]]
+  digest = "1:321081b4a44256715f2b68411d8eda9a17f17ebfe6f0cc61d2cc52d11c08acfa"
+  name = "sigs.k8s.io/yaml"
+  packages = ["."]
+  pruneopts = ""
+  revision = "fd68e9863619f6ec2fdd8625fe1f02e7c877e480"
+  version = "v1.1.0"
+
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
     "github.com/fsnotify/fsnotify",
     "github.com/golang/protobuf/ptypes/timestamp",
+    "github.com/nalej/deployment-manager/pkg/kubernetes",
     "github.com/nalej/derrors",
     "github.com/nalej/grpc-app-cluster-api-go",
     "github.com/nalej/grpc-common-go",
@@ -584,6 +965,9 @@
     "google.golang.org/grpc/credentials",
     "google.golang.org/grpc/reflection",
     "google.golang.org/grpc/test/bufconn",
+    "k8s.io/api/core/v1",
+    "k8s.io/apimachinery/pkg/apis/meta/v1",
+    "k8s.io/client-go/kubernetes",
   ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -393,6 +393,14 @@
   version = "v1.7.1"
 
 [[projects]]
+  digest = "1:4c0404dc03d974acd5fcd8b8d3ce687b13bd169db032b89275e8b9d77b98ce8c"
+  name = "github.com/patrickmn/go-cache"
+  packages = ["."]
+  pruneopts = ""
+  revision = "a3647f8e31d79543b2d0f0ae2fe5c379d72cedc0"
+  version = "v2.1.0"
+
+[[projects]]
   digest = "1:f3e56d302f80d760e718743f89f4e7eaae532d4218ba330e979bd051f78de141"
   name = "github.com/prometheus/client_golang"
   packages = [
@@ -865,6 +873,7 @@
     "github.com/nalej/grpc-utils/pkg/test",
     "github.com/onsi/ginkgo",
     "github.com/onsi/gomega",
+    "github.com/patrickmn/go-cache",
     "github.com/prometheus/client_golang/api",
     "github.com/prometheus/client_golang/api/prometheus/v1",
     "github.com/prometheus/client_golang/prometheus",

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -37,14 +37,6 @@
   version = "v1.3.1"
 
 [[projects]]
-  branch = "master"
-  digest = "1:107b233e45174dbab5b1324201d092ea9448e58243ab9f039e4c0f332e121e3a"
-  name = "github.com/golang/glog"
-  packages = ["."]
-  pruneopts = ""
-  revision = "23def4e6c14b4da8ac2ed8007337bc5eb5007998"
-
-[[projects]]
   digest = "1:b852d2b62be24e445fcdbad9ce3015b44c207815d631230dfce3f14e7803f5bf"
   name = "github.com/golang/protobuf"
   packages = [
@@ -62,14 +54,6 @@
   pruneopts = ""
   revision = "6c65a5562fc06764971b7c5d05c76c75e84bdbf7"
   version = "v1.3.2"
-
-[[projects]]
-  digest = "1:1e5b1e14524ed08301977b7b8e10c719ed853cbf3f24ecb66fae783a46f207a6"
-  name = "github.com/google/btree"
-  packages = ["."]
-  pruneopts = ""
-  revision = "4030bb1f1f0c35b30ca7009e9ebd06849dd45306"
-  version = "v1.0.0"
 
 [[projects]]
   digest = "1:8d4a577a9643f713c25a32151c0f26af7228b4b97a219b5ddb7fd38d16f6e673"
@@ -92,17 +76,6 @@
   version = "v0.3.1"
 
 [[projects]]
-  branch = "master"
-  digest = "1:e1fd67b5695fb12f54f979606c5d650a5aa72ef242f8e71072bfd4f7b5a141a0"
-  name = "github.com/gregjones/httpcache"
-  packages = [
-    ".",
-    "diskcache",
-  ]
-  pruneopts = ""
-  revision = "901d90724c7919163f472a9812253fb26761123d"
-
-[[projects]]
   digest = "1:a82fe90cbcaf5dfc8267a0b49e0ab0a67c636532c83b21326f5000817ef20d5b"
   name = "github.com/grpc-ecosystem/grpc-gateway"
   packages = [
@@ -113,17 +86,6 @@
   pruneopts = ""
   revision = "f7120437bb4f6c71f7f5076ad65a45310de2c009"
   version = "v1.12.1"
-
-[[projects]]
-  digest = "1:7f6f07500a0b7d3766b00fa466040b97f2f5b5f3eef2ecabfe516e703b05119a"
-  name = "github.com/hashicorp/golang-lru"
-  packages = [
-    ".",
-    "simplelru",
-  ]
-  pruneopts = ""
-  revision = "7f827b33c0f158ec5dfbba01bb0b14a4541fd81d"
-  version = "v0.5.3"
 
 [[projects]]
   digest = "1:b3c5b95e56c06f5aa72cb2500e6ee5f44fcd122872d4fec2023a488e561218bc"
@@ -138,14 +100,6 @@
   pruneopts = ""
   revision = "a30252cb686a21eb2d0b98132633053ec2f7f1e5"
   version = "v1.0.0"
-
-[[projects]]
-  digest = "1:6906c992632a66c125bd44e68a7abc354d9eda683e451b5c2d9b1614d15d4f18"
-  name = "github.com/imdario/mergo"
-  packages = ["."]
-  pruneopts = ""
-  revision = "1afb36080aec31e0d1528973ebe6721b191b0369"
-  version = "v0.3.8"
 
 [[projects]]
   digest = "1:870d441fe217b8e689d7949fef6e43efbc787e50f200cb1e70dbca9204a1d6be"
@@ -188,25 +142,6 @@
   version = "1.0.1"
 
 [[projects]]
-  digest = "1:4bc382a76fc85eaea5a9a8c7c79d6e8285a1dc1b346c91e8287bdf70558b1d90"
-  name = "github.com/nalej/deployment-manager"
-  packages = [
-    "internal/entities",
-    "internal/structures/monitor",
-    "pkg/common",
-    "pkg/config",
-    "pkg/executor",
-    "pkg/kubernetes",
-    "pkg/kubernetes/events",
-    "pkg/metrics",
-    "pkg/utils",
-    "version",
-  ]
-  pruneopts = ""
-  revision = "c4bcc5b63851087037708490931411b28bfd33a2"
-  version = "v0.4.0"
-
-[[projects]]
   digest = "1:b651ba0ea8155a78a3a2b23e4cc86f85c44ce62856a565632444eb418d0d960e"
   name = "github.com/nalej/derrors"
   packages = ["."]
@@ -231,12 +166,12 @@
   version = "v0.0.26"
 
 [[projects]]
-  digest = "1:b6844eec3faae47051ba88f4c003264e94833a3cc74de0f7e6bd936ccf7ca19b"
+  digest = "1:db80629ec1cb6f46cf6c92f350131811fc773fc67b5f9d5b57a84c1a01183613"
   name = "github.com/nalej/grpc-application-go"
   packages = ["."]
   pruneopts = ""
-  revision = "27d9d79c7f2d3967057c0934355660d6615d1c45"
-  version = "v0.0.86"
+  revision = "23d094052316a074143e6fc61c5436320c8e2fb0"
+  version = "v0.0.91"
 
 [[projects]]
   digest = "1:14935510a150a010a7cb713d816fe04abc36fca1130778c36d1f0be7b15cc9e0"
@@ -271,12 +206,12 @@
   version = "v0.0.38"
 
 [[projects]]
-  digest = "1:b20974f33d5927364de58b99328ee8bdbb23fa0911a92e3a868afec5d92d5466"
+  digest = "1:442429f610e3934106628ab549ddce78c45195ded6ba88ad76339b2a7756dc27"
   name = "github.com/nalej/grpc-conductor-go"
   packages = ["."]
   pruneopts = ""
-  revision = "7895e36f8e79a9219e48f5a1c72296d1f3928231"
-  version = "v0.0.92"
+  revision = "9cbe44351c8dbd004186abc61dff0430d497022a"
+  version = "v0.0.96"
 
 [[projects]]
   digest = "1:98b6027953482c9efb9ff40892c51d876d819a3a58543c7b5eb7c099c90d2d13"
@@ -287,12 +222,12 @@
   version = "v0.0.4"
 
 [[projects]]
-  digest = "1:48da8aeeabb8f5ae90903b1f1e38174bc181ab47f57fd1e8e92acefdffb16d0c"
+  digest = "1:b23dd1094f2e65cf138000ced92de82d70b0811b8a3fc03e7e4df79bba44e751"
   name = "github.com/nalej/grpc-deployment-manager-go"
   packages = ["."]
   pruneopts = ""
-  revision = "c225918c521b22fe9c6409fb07ae867c91de890e"
-  version = "v0.0.63"
+  revision = "96a4d8dd785889c54cab647b604bb1d45fe57f00"
+  version = "v0.0.64"
 
 [[projects]]
   digest = "1:26321a3340b5dde398bd8ec308e3b54d129e55a9cd70cdba293a63f729244c80"
@@ -335,14 +270,6 @@
   version = "v0.0.49"
 
 [[projects]]
-  digest = "1:b73cffaf6365350acb43710662f5a38d3d0532f9b687f8283d0fcfc56d800eed"
-  name = "github.com/nalej/grpc-installer-go"
-  packages = ["."]
-  pruneopts = ""
-  revision = "8224f729b66293d88afaa6b3c4ec91b60f6f6b7c"
-  version = "v0.0.35"
-
-[[projects]]
   digest = "1:52d4ed526ec58b9544a3cec008022015f95d025032a82320f8e53a799cc1d721"
   name = "github.com/nalej/grpc-inventory-go"
   packages = ["."]
@@ -367,12 +294,12 @@
   version = "v0.0.12"
 
 [[projects]]
-  digest = "1:c824ac5b757663d20803e64ba66757c4678c5a338401305ad021069d3cefbc45"
+  digest = "1:a38c55f4ee4da38689b71b5fbd0d0f2902657546dd39d49e5a5beb8c6b4f1e5c"
   name = "github.com/nalej/grpc-network-go"
   packages = ["."]
   pruneopts = ""
-  revision = "2041cb4a8fcd8ba7972c739aaa34b3e0713b9cda"
-  version = "v0.0.45"
+  revision = "d16d18d906572a8eab6419951f140753f28fcd54"
+  version = "v0.0.46"
 
 [[projects]]
   digest = "1:ba1b6bc93bc388dddeb0db8975ca32312921508dfff13803fb58c623c2350908"
@@ -466,23 +393,7 @@
   version = "v1.7.1"
 
 [[projects]]
-  branch = "master"
-  digest = "1:5f0faa008e8ff4221b55a1a5057c8b02cb2fd68da6a65c9e31c82b72cbc836d0"
-  name = "github.com/petar/GoLLRB"
-  packages = ["llrb"]
-  pruneopts = ""
-  revision = "33fb24c13b99c46c93183c291836c573ac382536"
-
-[[projects]]
-  digest = "1:4709c61d984ef9ba99b037b047546d8a576ae984fb49486e48d99658aa750cd5"
-  name = "github.com/peterbourgon/diskv"
-  packages = ["."]
-  pruneopts = ""
-  revision = "0be1b92a6df0e4f5cb0a5d15fb7f643d0ad93ce6"
-  version = "v3.0.0"
-
-[[projects]]
-  digest = "1:6f218995d6a74636cfcab45ce03005371e682b4b9bee0e5eb0ccfd83ef85364f"
+  digest = "1:f3e56d302f80d760e718743f89f4e7eaae532d4218ba330e979bd051f78de141"
   name = "github.com/prometheus/client_golang"
   packages = [
     "api",
@@ -492,8 +403,8 @@
     "prometheus/promhttp",
   ]
   pruneopts = ""
-  revision = "505eaef017263e299324067d40ca2c48f6a2cf50"
-  version = "v0.9.2"
+  revision = "1cafe34db7fdec6022e17e00e1c1ea501022f3e4"
+  version = "v0.9.0"
 
 [[projects]]
   branch = "master"
@@ -566,7 +477,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:f58e146d19d1af39792c0b599b24b13de51f75b073ba52c1aa658fe535be9120"
+  digest = "1:03e60ff96fcef15b255431bf7c9122e266a3355b8d130d6e2f0d0c399570993a"
   name = "golang.org/x/net"
   packages = [
     "context",
@@ -582,7 +493,7 @@
     "trace",
   ]
   pruneopts = ""
-  revision = "ef20fe5d793301b553005db740f730d87993f778"
+  revision = "5ee1b9f4859acd2e99987ef94ec7a58427c53bef"
 
 [[projects]]
   branch = "master"
@@ -597,14 +508,14 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:6530ff3e6639af9bab7d2cf1e141c348e63af92058fa64d0660a6e8817d41640"
+  digest = "1:37766ea00675c25129361a0519c178d47e373bc144d4fad349c285e20e32d5e8"
   name = "golang.org/x/sys"
   packages = [
     "unix",
     "windows",
   ]
   pruneopts = ""
-  revision = "6d18c012aee9febd81bbf9806760c8c4480e870d"
+  revision = "ce4227a45e2eb77e5c847278dcc6a626742e2945"
 
 [[projects]]
   digest = "1:740b51a55815493a8d0f2b1e0d0ae48fe48953bf7eaf3fcc4198823bf67768c0"
@@ -669,7 +580,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:a51a58f22fcdcf4238ee8b2a3a9637cbdb73320183038ce20c104f682563c640"
+  digest = "1:46eb383c079b79b4dc249421ebf6db29def0757a3b3a1941f62dc553345ed464"
   name = "google.golang.org/genproto"
   packages = [
     "googleapis/api/annotations",
@@ -679,7 +590,7 @@
     "protobuf/field_mask",
   ]
   pruneopts = ""
-  revision = "83cc0476cb11ea0da33dacd4c6354ab192de6fe6"
+  revision = "3fa9dbf08042c806feeb0b21b23e07587714c143"
 
 [[projects]]
   digest = "1:ec89356e95f2a8983928a7872f71f0f934f97932353af4fe1a76d322db5eaf7b"
@@ -762,14 +673,14 @@
   version = "v2.2.7"
 
 [[projects]]
-  digest = "1:8a3902b1f1aab51953de9741e4a62daaab441788d85ba7f50709ceca8e26b6ff"
+  digest = "1:46d8aaaf9d03291ce0989e34af05ede74b81ab193f3dd8bc9263487a0722b931"
   name = "k8s.io/api"
   packages = [
-    "admissionregistration/v1alpha1",
     "admissionregistration/v1beta1",
     "apps/v1",
     "apps/v1beta1",
     "apps/v1beta2",
+    "auditregistration/v1alpha1",
     "authentication/v1",
     "authentication/v1beta1",
     "authorization/v1",
@@ -781,15 +692,20 @@
     "batch/v1beta1",
     "batch/v2alpha1",
     "certificates/v1beta1",
+    "coordination/v1",
     "coordination/v1beta1",
     "core/v1",
     "events/v1beta1",
     "extensions/v1beta1",
     "networking/v1",
+    "networking/v1beta1",
+    "node/v1alpha1",
+    "node/v1beta1",
     "policy/v1beta1",
     "rbac/v1",
     "rbac/v1alpha1",
     "rbac/v1beta1",
+    "scheduling/v1",
     "scheduling/v1alpha1",
     "scheduling/v1beta1",
     "settings/v1alpha1",
@@ -798,20 +714,18 @@
     "storage/v1beta1",
   ]
   pruneopts = ""
-  revision = "5cb15d34447165a97c76ed5a60e4e99c8a01ecfe"
-  version = "kubernetes-1.13.5"
+  revision = "2cd11237263f515cf13ca56d2b6c6c48a4158396"
+  version = "kubernetes-1.15.6"
 
 [[projects]]
-  digest = "1:c05610391a133b223e1736a3b8cbd725da30f64c0c6a93d6422714ccfd8f4a73"
+  digest = "1:86667aeeaaad11106ab0f509e7949bfff5d25ece5c59ac25556f367566a46e80"
   name = "k8s.io/apimachinery"
   packages = [
     "pkg/api/errors",
     "pkg/api/meta",
     "pkg/api/resource",
-    "pkg/apis/meta/internalversion",
     "pkg/apis/meta/v1",
     "pkg/apis/meta/v1/unstructured",
-    "pkg/apis/meta/v1beta1",
     "pkg/conversion",
     "pkg/conversion/queryparams",
     "pkg/fields",
@@ -826,9 +740,7 @@
     "pkg/runtime/serializer/versioning",
     "pkg/selection",
     "pkg/types",
-    "pkg/util/cache",
     "pkg/util/clock",
-    "pkg/util/diff",
     "pkg/util/errors",
     "pkg/util/framer",
     "pkg/util/intstr",
@@ -839,28 +751,27 @@
     "pkg/util/sets",
     "pkg/util/validation",
     "pkg/util/validation/field",
-    "pkg/util/wait",
     "pkg/util/yaml",
     "pkg/version",
     "pkg/watch",
     "third_party/forked/golang/reflect",
   ]
   pruneopts = ""
-  revision = "86fb29eff6288413d76bd8506874fddd9fccdff0"
-  version = "kubernetes-1.13.5"
+  revision = "31ade1b30762be61c32b2e8db2a11aa8b0b8960e"
+  version = "kubernetes-1.15.6"
 
 [[projects]]
-  digest = "1:5d4153d12c3aed2c90a94262520d2498d5afa4d692554af55e65a7c5af0bc399"
+  digest = "1:97653c6f367a120e08a463452ee2a5c58ce070eb0947f8d2b4687178e5799cf6"
   name = "k8s.io/client-go"
   packages = [
     "discovery",
     "kubernetes",
     "kubernetes/scheme",
-    "kubernetes/typed/admissionregistration/v1alpha1",
     "kubernetes/typed/admissionregistration/v1beta1",
     "kubernetes/typed/apps/v1",
     "kubernetes/typed/apps/v1beta1",
     "kubernetes/typed/apps/v1beta2",
+    "kubernetes/typed/auditregistration/v1alpha1",
     "kubernetes/typed/authentication/v1",
     "kubernetes/typed/authentication/v1beta1",
     "kubernetes/typed/authorization/v1",
@@ -872,15 +783,20 @@
     "kubernetes/typed/batch/v1beta1",
     "kubernetes/typed/batch/v2alpha1",
     "kubernetes/typed/certificates/v1beta1",
+    "kubernetes/typed/coordination/v1",
     "kubernetes/typed/coordination/v1beta1",
     "kubernetes/typed/core/v1",
     "kubernetes/typed/events/v1beta1",
     "kubernetes/typed/extensions/v1beta1",
     "kubernetes/typed/networking/v1",
+    "kubernetes/typed/networking/v1beta1",
+    "kubernetes/typed/node/v1alpha1",
+    "kubernetes/typed/node/v1beta1",
     "kubernetes/typed/policy/v1beta1",
     "kubernetes/typed/rbac/v1",
     "kubernetes/typed/rbac/v1alpha1",
     "kubernetes/typed/rbac/v1beta1",
+    "kubernetes/typed/scheduling/v1",
     "kubernetes/typed/scheduling/v1alpha1",
     "kubernetes/typed/scheduling/v1beta1",
     "kubernetes/typed/settings/v1alpha1",
@@ -894,29 +810,18 @@
     "plugin/pkg/client/auth/exec",
     "rest",
     "rest/watch",
-    "restmapper",
-    "tools/auth",
-    "tools/cache",
-    "tools/clientcmd",
     "tools/clientcmd/api",
-    "tools/clientcmd/api/latest",
-    "tools/clientcmd/api/v1",
     "tools/metrics",
-    "tools/pager",
     "tools/reference",
     "transport",
-    "util/buffer",
     "util/cert",
     "util/connrotation",
     "util/flowcontrol",
-    "util/homedir",
-    "util/integer",
-    "util/retry",
-    "util/workqueue",
+    "util/keyutil",
   ]
   pruneopts = ""
-  revision = "1638f8970cefaa404ff3a62950f88b08292b2696"
-  version = "v9.0.0"
+  revision = "8cba805ad12d699a43f2fe96dbfbcf3042133e89"
+  version = "kubernetes-1.15.6"
 
 [[projects]]
   digest = "1:7ce71844fcaaabcbe09a392902edb5790ddca3a7070ae8d20830dc6dbe2751af"
@@ -925,6 +830,14 @@
   pruneopts = ""
   revision = "2ca9ad30301bf30a8a6e0fa2110db6b8df699a91"
   version = "v1.0.0"
+
+[[projects]]
+  branch = "master"
+  digest = "1:a8a2e6bbef691323b833d0eb11bb0e570e7eb9619ac76f7b11265530e1cac922"
+  name = "k8s.io/utils"
+  packages = ["integer"]
+  pruneopts = ""
+  revision = "6ca3b61696b65b0e81f1a39b4937fc2d2994ed6a"
 
 [[projects]]
   digest = "1:321081b4a44256715f2b68411d8eda9a17f17ebfe6f0cc61d2cc52d11c08acfa"
@@ -940,7 +853,6 @@
   input-imports = [
     "github.com/fsnotify/fsnotify",
     "github.com/golang/protobuf/ptypes/timestamp",
-    "github.com/nalej/deployment-manager/pkg/kubernetes",
     "github.com/nalej/derrors",
     "github.com/nalej/grpc-app-cluster-api-go",
     "github.com/nalej/grpc-common-go",
@@ -968,6 +880,7 @@
     "k8s.io/api/core/v1",
     "k8s.io/apimachinery/pkg/apis/meta/v1",
     "k8s.io/client-go/kubernetes",
+    "k8s.io/client-go/rest",
   ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -19,6 +19,14 @@
   version="v0.0.3"
 
 [[constraint]]
+    name="k8s.io/client-go"
+    version="v9.0.0"
+
+[[constraint]]
+   name = "k8s.io/apimachinery"
+   version="kubernetes-1.13.5"
+
+[[constraint]]
   name = "google.golang.org/grpc"
   version = "v1.18.0"
 
@@ -36,7 +44,7 @@
 
 [[constraint]]
   name = "github.com/nalej/grpc-monitoring-go"
-  version = "v0.0.9"
+  version = "v0.0.12"
 
 [[constraint]]
   name = "github.com/nalej/grpc-inventory-go"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -20,11 +20,15 @@
 
 [[constraint]]
     name="k8s.io/client-go"
-    version="v9.0.0"
+    version="kubernetes-1.15.6"
+
+[[constraint]]
+   name = "k8s.io/api"
+   version="kubernetes-1.15.6"
 
 [[constraint]]
    name = "k8s.io/apimachinery"
-   version="kubernetes-1.13.5"
+   version="kubernetes-1.15.6"
 
 [[constraint]]
   name = "google.golang.org/grpc"
@@ -40,7 +44,7 @@
 
 [[constraint]]
   name = "github.com/prometheus/client_golang"
-  version = "=v0.9.2"
+  version = "=v0.9.0"
 
 [[constraint]]
   name = "github.com/nalej/grpc-monitoring-go"
@@ -69,3 +73,7 @@
 [[constraint]]
   name = "github.com/fsnotify/fsnotify"
   version = "v1.4.7"
+
+[[constraint]]
+  name = "github.com/patrickmn/go-cache"
+  version = "v2.1.0"

--- a/cmd/monitoring-manager/commands/run.go
+++ b/cmd/monitoring-manager/commands/run.go
@@ -20,6 +20,7 @@ import (
 	"github.com/nalej/monitoring/internal/pkg/monitoring-manager/server"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
+	"time"
 )
 
 var config = server.Config{}
@@ -44,19 +45,20 @@ func init() {
 	runCmd.PersistentFlags().BoolVar(&config.SkipServerCertValidation, "skipServerCertValidation", false, "Don't validate TLS certificates")
 	runCmd.PersistentFlags().StringVar(&config.CACertPath, "caCertPath", "", "Alternative certificate path to use for validation")
 	runCmd.PersistentFlags().StringVar(&config.ClientCertPath, "clientCertPath", "", "Client cert path")
+	runCmd.PersistentFlags().DurationVar(&config.CacheTTL, "cacheTTL", time.Minute, "TTL duration for the stats cache (ex: 10s, 5m). Defaults to 1m (1 minute).")
 	rootCmd.AddCommand(runCmd)
 }
 
 func Run() {
 	log.Info().Msg("Launching Monitoring Manager service")
 
-	server, err := server.NewService(&config)
+	service, err := server.NewService(&config)
 	if err != nil {
 		log.Fatal().Str("err", err.DebugReport()).Err(err)
 		panic(err.Error())
 	}
 
-	err = server.Run()
+	err = service.Run()
 	if err != nil {
 		log.Fatal().Str("err", err.DebugReport()).Err(err)
 		panic(err.Error())

--- a/internal/pkg/metrics-collector/server/metrics_collector_suite_test.go
+++ b/internal/pkg/metrics-collector/server/metrics_collector_suite_test.go
@@ -200,7 +200,7 @@ func beforeSuiteRetrieveManager() {
 		provider.ProviderType(): provider,
 	}
 
-	manager, derr = NewManager(providers)
+	manager, derr = NewManager(providers, nil)
 	gomega.Expect(derr).To(gomega.Succeed())
 
 	/* Insert fake provider */

--- a/internal/pkg/monitoring-manager/clients/cluster_client.go
+++ b/internal/pkg/monitoring-manager/clients/cluster_client.go
@@ -35,7 +35,7 @@ import (
 	"google.golang.org/grpc/credentials"
 )
 
-type ClusterClient struct {
+type MetricsCollectorClient struct {
 	grpc_app_cluster_api_go.MetricsCollectorClient
 	conn *grpc.ClientConn
 }
@@ -51,7 +51,7 @@ type AppClusterConnectParams struct {
 
 // TODO: If we want to test this, we can create a client factory and implement
 // one that creates stub clients
-func NewClusterClient(address string, params *AppClusterConnectParams) (*ClusterClient, derrors.Error) {
+func NewMetricsCollectorClient(address string, params *AppClusterConnectParams) (*MetricsCollectorClient, derrors.Error) {
 	var options []grpc.DialOption
 	var hostname string
 
@@ -123,10 +123,10 @@ func NewClusterClient(address string, params *AppClusterConnectParams) (*Cluster
 
 	client := grpc_app_cluster_api_go.NewMetricsCollectorClient(conn)
 
-	return &ClusterClient{client, conn}, nil
+	return &MetricsCollectorClient{client, conn}, nil
 }
 
-func (c *ClusterClient) Close() error {
+func (c *MetricsCollectorClient) Close() error {
 	err := c.conn.Close()
 	if err != nil {
 		log.Warn().Msg("error closing client connection")

--- a/internal/pkg/monitoring-manager/server/config.go
+++ b/internal/pkg/monitoring-manager/server/config.go
@@ -22,28 +22,31 @@ import (
 	"github.com/nalej/derrors"
 	"github.com/nalej/monitoring/version"
 	"github.com/rs/zerolog/log"
+	"time"
 )
 
 // Config struct for the API service.
 type Config struct {
 	// Port where the API service will listen requests.
 	Port int
-	// Address with host:port of the system model component
+	// SystemModelAddress is the address with host:port of the system model component.
 	SystemModelAddress string
-	// EdgeInventoryProxyAddress with host:port of the edge inventory proxy
+	// EdgeInventoryProxyAddress with host:port of the edge inventory proxy.
 	EdgeInventoryProxyAddress string
-	// Prefix for application cluster hostnames
+	// AppClusterPrefix is the prefix for application cluster hostnames.
 	AppClusterPrefix string
-	// Port used by app-cluster-api
+	// AppClusterPort is the port used by app-cluster-api.
 	AppClusterPort int
-	// Use TLS
+	// UseTLS Use or not TLS.
 	UseTLS bool
-	// Don't validate TLS certificates
+	// SkipServerCertValidation Don't validate TLS certificates.
 	SkipServerCertValidation bool
-	// Alternative certificate file to use for validation
+	// CACertPath Alternative certificate file to use for validation.
 	CACertPath string
-	// Client Cert Path
+	// ClientCertPath Client Cert Path.
 	ClientCertPath string
+	// CacheTTL is the default duration for cache entries.
+	CacheTTL time.Duration
 }
 
 // Validate the configuration.
@@ -78,4 +81,5 @@ func (conf *Config) Print() {
 	log.Info().Str("prefix", conf.AppClusterPrefix).Msg("appClusterPrefix")
 	log.Info().Int("port", conf.AppClusterPort).Msg("appClusterPort")
 	log.Info().Bool("tls", conf.UseTLS).Bool("skipServerCertValidation", conf.SkipServerCertValidation).Str("cert", conf.CACertPath).Str("cert", conf.ClientCertPath).Msg("TLS parameters")
+	log.Info().Dur("CacheTTL", conf.CacheTTL).Msg("selected TTL for the stats cache in milliseconds")
 }

--- a/internal/pkg/monitoring-manager/server/manager.go
+++ b/internal/pkg/monitoring-manager/server/manager.go
@@ -20,8 +20,11 @@ package server
 
 import (
 	"context"
+	"github.com/nalej/grpc-common-go"
 	"github.com/nalej/grpc-organization-go"
 	"github.com/nalej/monitoring/internal/pkg/monitoring-manager/clients"
+	"github.com/rs/zerolog/log"
+	"time"
 
 	"github.com/nalej/derrors"
 
@@ -29,38 +32,53 @@ import (
 	"github.com/nalej/grpc-monitoring-go"
 )
 
+const (
+	defaultTimeout = 10 * time.Second
+)
+
 type Manager struct {
-	clustersClient grpc_infrastructure_go.ClustersClient
-	params         *clients.AppClusterConnectParams
+	clustersClient      *grpc_infrastructure_go.ClustersClient
+	organizationsClient *grpc_organization_go.OrganizationsClient
+
+	params *clients.AppClusterConnectParams
+}
+
+func (m *Manager) getOrganizationsClient() grpc_organization_go.OrganizationsClient {
+	return *m.organizationsClient
+}
+
+func (m *Manager) getClustersClient() grpc_infrastructure_go.ClustersClient {
+	return *m.clustersClient
 }
 
 // Create a new query manager.
-func NewManager(clustersClient grpc_infrastructure_go.ClustersClient, params *clients.AppClusterConnectParams) (Manager, derrors.Error) {
+func NewManager(clustersClient *grpc_infrastructure_go.ClustersClient, organizationsClient *grpc_organization_go.OrganizationsClient, params *clients.AppClusterConnectParams) (Manager, derrors.Error) {
 	manager := Manager{
-		clustersClient: clustersClient,
-		params:         params,
+		clustersClient:      clustersClient,
+		organizationsClient: organizationsClient,
+		params:              params,
 	}
 
 	return manager, nil
 }
 
-func (m *Manager) getClusterClient(organizationId, clusterId string) (*clients.ClusterClient, derrors.Error) {
+func (m *Manager) getMetricsCollectorClient(organizationId, clusterId string) (*clients.MetricsCollectorClient, derrors.Error) {
 	getClusterRequest := &grpc_infrastructure_go.ClusterId{
 		OrganizationId: organizationId,
 		ClusterId:      clusterId,
 	}
 
-	cluster, err := m.clustersClient.GetCluster(context.Background(), getClusterRequest)
+	cluster, err := m.getClustersClient().GetCluster(context.Background(), getClusterRequest)
 	if err != nil || cluster == nil {
 		return nil, derrors.NewUnavailableError("unable to retrieve cluster", err)
 	}
 
-	return clients.NewClusterClient(cluster.GetHostname(), m.params)
+	return clients.NewMetricsCollectorClient(cluster.GetHostname(), m.params)
 }
 
 // Retrieve a summary of high level cluster resource availability
 func (m *Manager) GetClusterSummary(ctx context.Context, request *grpc_monitoring_go.ClusterSummaryRequest) (*grpc_monitoring_go.ClusterSummary, error) {
-	client, derr := m.getClusterClient(request.GetOrganizationId(), request.GetClusterId())
+	client, derr := m.getMetricsCollectorClient(request.GetOrganizationId(), request.GetClusterId())
 	if derr != nil {
 		return nil, derr
 	}
@@ -76,7 +94,7 @@ func (m *Manager) GetClusterSummary(ctx context.Context, request *grpc_monitorin
 
 // Retrieve statistics on cluster with respect to platform resources
 func (m *Manager) GetClusterStats(ctx context.Context, request *grpc_monitoring_go.ClusterStatsRequest) (*grpc_monitoring_go.ClusterStats, error) {
-	client, derr := m.getClusterClient(request.GetOrganizationId(), request.GetClusterId())
+	client, derr := m.getMetricsCollectorClient(request.GetOrganizationId(), request.GetClusterId())
 	if derr != nil {
 		return nil, derr
 	}
@@ -92,7 +110,7 @@ func (m *Manager) GetClusterStats(ctx context.Context, request *grpc_monitoring_
 
 // Execute a query directly on the monitoring storage backend
 func (m *Manager) Query(ctx context.Context, request *grpc_monitoring_go.QueryRequest) (*grpc_monitoring_go.QueryResponse, error) {
-	client, derr := m.getClusterClient(request.GetOrganizationId(), request.GetClusterId())
+	client, derr := m.getMetricsCollectorClient(request.GetOrganizationId(), request.GetClusterId())
 	if derr != nil {
 		return nil, derr
 	}
@@ -107,43 +125,84 @@ func (m *Manager) Query(ctx context.Context, request *grpc_monitoring_go.QueryRe
 }
 
 func (m *Manager) GetOrganizationApplicationStats(ctx context.Context, request *grpc_monitoring_go.OrganizationApplicationStatsRequest) (*grpc_monitoring_go.OrganizationApplicationStatsResponse, error) {
-	clusterList, err := m.clustersClient.ListClusters(ctx, &grpc_organization_go.OrganizationId{OrganizationId: request.OrganizationId})
+	getOrganizationCtx, getOrganizationCancel := context.WithTimeout(ctx, defaultTimeout)
+	defer getOrganizationCancel()
+	organization, err := m.getOrganizationsClient().GetOrganization(getOrganizationCtx, &grpc_organization_go.OrganizationId{OrganizationId: request.OrganizationId})
 	if err != nil {
-		return nil, derrors.NewFailedPreconditionError("could not find cluster list", err)
+		return nil, derrors.NewFailedPreconditionError("could not get organization", err)
+	}
+	organizationName := organization.Name
+
+	listClustersCtx, listclustersCancel := context.WithTimeout(ctx, defaultTimeout)
+	defer listclustersCancel()
+	clusterList, err := m.getClustersClient().ListClusters(listClustersCtx, &grpc_organization_go.OrganizationId{OrganizationId: request.OrganizationId})
+	if err != nil {
+		return nil, derrors.NewFailedPreconditionError("could not geet cluster list", err)
 	}
 
-	serviceInstanceStats := make([]*grpc_monitoring_go.OrganizationApplicationStats, 0)
+	containerStatsFutures := make([]chan *grpc_monitoring_go.ContainerStatsResponse, 0)
+	for _, cluster := range clusterList.Clusters {
+		metricsCollector, derr := m.getMetricsCollectorClient(organization.OrganizationId, cluster.ClusterId)
+		if derr != nil {
+			log.Error().
+				Str("organizationId", organization.OrganizationId).
+				Str("clusterId", cluster.ClusterId).
+				Err(derr).
+				Msg("could not create metrics-collector client. The aggregation will not include this cluster stats.")
+			continue
+		}
+		statsFuture := make(chan *grpc_monitoring_go.ContainerStatsResponse)
+		containerStatsFutures = append(containerStatsFutures, statsFuture)
+		go func() {
+			getClusterContainerStats(cluster, metricsCollector, ctx, statsFuture)
+		}()
+	}
+
+	orgContainerStats := make([]*grpc_monitoring_go.ContainerStats, 0)
+	for _, statsFuture := range containerStatsFutures {
+		containerStatsResponse := <-statsFuture
+		orgContainerStats = append(orgContainerStats, containerStatsResponse.ContainerStats...)
+	}
+
+	serviceInstanceStats := make([]*grpc_monitoring_go.OrganizationApplicationStats, len(orgContainerStats))
+	for ix, containerStats := range orgContainerStats {
+		serviceInstanceStats[ix] = &grpc_monitoring_go.OrganizationApplicationStats{
+			OrganizationId:           request.OrganizationId,
+			OrganizationName:         organizationName,
+			AppInstanceId:            containerStats.AppInstanceId,
+			AppInstanceName:          containerStats.AppInstanceName,
+			ServiceGroupInstanceId:   containerStats.ServiceGroupInstanceId,
+			ServiceGroupInstanceName: containerStats.ServiceGroupInstanceName,
+			ServiceInstanceId:        containerStats.ServiceInstanceId,
+			ServiceInstanceName:      containerStats.ServiceInstanceName,
+			CpuMillicore:             containerStats.CpuMillicore,
+			MemoryByte:               containerStats.MemoryByte,
+			StorageByte:              containerStats.StorageByte,
+		}
+	}
 	orgAppStats := &grpc_monitoring_go.OrganizationApplicationStatsResponse{
 		ServiceInstanceStats: serviceInstanceStats,
 		Timestamp:            0,
 	}
-	for _, cluster := range clusterList.Clusters {
-		client, derr := m.getClusterClient(request.OrganizationId, cluster.ClusterId)
-		if derr != nil {
-			// TODO what to do if a cluster client cannot be created
-			continue
-		}
-		containerStats, err := client.GetContainerStats(ctx, nil)
-		if err != nil {
-			// TODO what to do if cluster do not respond with stats
-			continue
-		}
-		for _, stats := range containerStats.ContainerStats {
-			serviceInstanceStats = append(serviceInstanceStats, &grpc_monitoring_go.OrganizationApplicationStats{
-				OrganizationId: request.OrganizationId,
-				//OrganizationName:         organizationName, TODO
-				//AppInstanceId:            aooInstanceId, TODO
-				//AppInstanceName:          appInstanceNAme, TODO
-				//ServiceGroupInstanceId:   serviceGroupInstanceId, TODO
-				//ServiceGroupInstanceName: serviceGroupInstanceName, TODO
-				//ServiceInstanceId:        serviceInstanceId, TODO
-				//ServiceInstanceName:      serviceInstanceName, TODO
-				CpuMillicore: stats.CpuMillicore * cluster.MillicoresConversionFactor,
-				MemoryByte:   stats.MemoryByte,
-				StorageByte:  stats.StorageByte,
-			})
-		}
-	}
 
 	return orgAppStats, nil
+}
+
+func getClusterContainerStats(cluster *grpc_infrastructure_go.Cluster, metricsCollector *clients.MetricsCollectorClient, ctx context.Context, statsFuture chan *grpc_monitoring_go.ContainerStatsResponse) {
+	getContainerStatsCtx, getContainerStatsCancel := context.WithTimeout(ctx, defaultTimeout)
+	defer getContainerStatsCancel()
+	clusterContainerStats, err := metricsCollector.GetContainerStats(getContainerStatsCtx, &grpc_common_go.Empty{})
+	if err != nil {
+		log.Error().
+			Str("organizationId", cluster.OrganizationId).
+			Str("clusterId", cluster.ClusterId).
+			Err(err).
+			Msg("metrics-collector responded with an error when querying for stats. The aggregation will not include this cluster stats.")
+		statsFuture <- nil
+	}
+	// Adjust millicores metric with the cluster conversion factor
+	for _, containerStat := range clusterContainerStats.ContainerStats {
+		containerStat.CpuMillicore = containerStat.GetCpuMillicore() * cluster.MillicoresConversionFactor
+	}
+	statsFuture <- clusterContainerStats
 }

--- a/internal/pkg/monitoring-manager/server/manager.go
+++ b/internal/pkg/monitoring-manager/server/manager.go
@@ -182,7 +182,7 @@ func (m *Manager) GetOrganizationApplicationStats(ctx context.Context, request *
 	}
 	orgAppStats := &grpc_monitoring_go.OrganizationApplicationStatsResponse{
 		ServiceInstanceStats: serviceInstanceStats,
-		Timestamp:            0,
+		Timestamp:            time.Now().Unix(),
 	}
 
 	return orgAppStats, nil

--- a/internal/pkg/monitoring-manager/server/server.go
+++ b/internal/pkg/monitoring-manager/server/server.go
@@ -18,6 +18,7 @@ package server
 
 import (
 	"fmt"
+	grpc_organization_go "github.com/nalej/grpc-organization-go"
 	"github.com/nalej/monitoring/internal/pkg/monitoring-manager/clients"
 	"github.com/nalej/monitoring/internal/pkg/monitoring-manager/server/asset"
 	"net"
@@ -68,6 +69,7 @@ func (s *Service) Run() derrors.Error {
 
 	// Create clients
 	clustersClient := grpc_infrastructure_go.NewClustersClient(smConn)
+	organizationsClient := grpc_organization_go.NewOrganizationsClient(smConn)
 	assetsClient := grpc_inventory_go.NewAssetsClient(smConn)
 	controllersClient := grpc_inventory_go.NewControllersClient(smConn)
 	eipClient := grpc_edge_inventory_proxy_go.NewEdgeControllerProxyClient(eipConn)
@@ -89,7 +91,7 @@ func (s *Service) Run() derrors.Error {
 	}
 
 	// Cluster monitoring
-	clusterManager, derr := NewManager(clustersClient, params)
+	clusterManager, derr := NewManager(&clustersClient, &organizationsClient, params)
 	if derr != nil {
 		return derr
 	}

--- a/internal/pkg/monitoring-manager/server/server.go
+++ b/internal/pkg/monitoring-manager/server/server.go
@@ -95,7 +95,7 @@ func (s *Service) Run() derrors.Error {
 	if derr != nil {
 		return derr
 	}
-	clusterHandler, derr := NewHandler(clusterManager)
+	clusterHandler, derr := NewHandler(clusterManager, s.Configuration.CacheTTL)
 	if derr != nil {
 		return derr
 	}


### PR DESCRIPTION
#### What does this PR do?
Request al the application clusters for the container stats through `metrics-collector`.

#### How should this be manually tested?
after port-forwarding monitoring manager...
```shell script
grpcurl -plaintext -d '{"organization_id":"86a8cf10-d374-46c0-bfd0-0055df1eafdc"}' localhost:8423 monitoring.MonitoringManager/GetOrganizationApplicationStats
```

#### What are the relevant tickets?

- [NP-2388](https://nalej.atlassian.net/browse/NP-2388)
- [NP-2368](https://nalej.atlassian.net/browse/NP-2368)